### PR TITLE
Switch to use overlay2 in nodes

### DIFF
--- a/lib/kontena/machine/digital_ocean/cloudinit.yml
+++ b/lib/kontena/machine/digital_ocean/cloudinit.yml
@@ -11,7 +11,7 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-kontena.conf
     content: |
         [Service]
-        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/16" --bip="172.17.43.1/16"'
+        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/16" --bip="172.17.43.1/16" -s overlay2'
         Environment='DOCKER_CGROUPS=--exec-opt native.cgroupdriver=cgroupfs'
   - path: /etc/sysctl.d/99-inotify.conf
     owner: root


### PR DESCRIPTION
> Since version 1.12, Docker also provides overlay2 storage driver which is much more efficient than overlay in terms of inode utilization. The overlay2 driver is only compatible with Linux kernel 4.0 and later.