### PR TITLE
Show droplet type in prompt

### DIFF
--- a/lib/kontena/plugin/digital_ocean/nodes/create_command.rb
+++ b/lib/kontena/plugin/digital_ocean/nodes/create_command.rb
@@ -46,7 +46,7 @@ module Kontena::Plugin::DigitalOcean::Nodes
 
     def ask_droplet_count
       if self.count.nil?
-        prompt.ask('How many droplets?: ', default: 1)
+        prompt.ask('How many droplets?:', default: 1)
       else
         self.count
       end

--- a/lib/kontena/plugin/digital_ocean/prompts.rb
+++ b/lib/kontena/plugin/digital_ocean/prompts.rb
@@ -1,7 +1,7 @@
 module Kontena::Plugin::DigitalOcean::Prompts
   def ask_do_token
     if self.token.nil?
-      prompt.ask('DigitalOcean API token: ', echo: false)
+      prompt.ask('DigitalOcean API token:', echo: false)
     else
       self.token
     end
@@ -9,7 +9,7 @@ module Kontena::Plugin::DigitalOcean::Prompts
 
   def ask_droplet_region(do_token)
     if self.region.nil?
-      prompt.select("Choose a datacenter region: ") do |menu|
+      prompt.select("Choose a datacenter region:") do |menu|
         do_client = DropletKit::Client.new(access_token: do_token)
         do_client.regions.all.sort_by{|r| r.slug }.each{ |region|
           menu.choice region.name, region.slug
@@ -22,12 +22,13 @@ module Kontena::Plugin::DigitalOcean::Prompts
 
   def ask_droplet_size(do_token, do_region)
     if self.size.nil?
-      prompt.select("Choose droplet size: ") do |menu|
+      prompt.select("Choose droplet size:") do |menu|
         do_client = DropletKit::Client.new(access_token: do_token)
         do_client.sizes.all.to_a.select{ |s| s.memory > 1000 }.sort_by{|s| s.memory }.each{ |size|
+          #p size
           if size.regions.include?(do_region)
             memory = size.memory.to_i / 1024
-            menu.choice "#{memory}GB/#{size.vcpus}CPU/#{size.disk}GB ($#{size.price_monthly.to_i}/mo)", size.slug
+            menu.choice "#{size.slug}: #{memory}GB/#{size.vcpus}CPU/#{size.disk}GB ($#{size.price_monthly.to_i}/mo)", size.slug
           end
         }
       end
@@ -43,7 +44,7 @@ module Kontena::Plugin::DigitalOcean::Prompts
         n['labels'] && n['labels'].include?('provider=digitalocean'.freeze)
       }
       raise "Did not find any nodes with label provider=digitalocean" if nodes.size == 0
-      prompt.select("Select node: ") do |menu|
+      prompt.select("Select node:") do |menu|
         nodes.sort_by{|n| n['node_number'] }.reverse.each do |node|
           initial = node['initial_member'] ? '(initial) ' : ''
           menu.choice "#{node['name']} #{initial}", node['name']
@@ -55,7 +56,7 @@ module Kontena::Plugin::DigitalOcean::Prompts
   end
 
   def ask_channel
-    prompt.select('Select CoreOS channel') do |menu|
+    prompt.select('Select Container Linux channel:') do |menu|
       menu.choice 'Stable', 'stable'
       menu.choice 'Beta', 'beta'
       menu.choice 'Alpha', 'alpha'


### PR DESCRIPTION
```
$ kontena digitalocean node create
> Choose a datacenter region: New York 3
> Select Container Linux channel: Stable
> Choose droplet size: (Use arrow keys, press Enter to select)
‣ 1gb: 1GB/1CPU/30GB ($10/mo)
  2gb: 2GB/2CPU/40GB ($20/mo)
  c-2: 3GB/2CPU/20GB ($40/mo)
  4gb: 4GB/2CPU/60GB ($40/mo)
  c-4: 6GB/4CPU/20GB ($80/mo)
  8gb: 8GB/4CPU/80GB ($80/mo)
```